### PR TITLE
OS agnostic method to extract filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# working folder for local code not to be sent to the repo 
+working/

--- a/Qubitrix/sounds/__init__.py
+++ b/Qubitrix/sounds/__init__.py
@@ -48,7 +48,7 @@ class Effect:
         """
         if not mixer.get_init():
             mixer.init()
-        self.name = sound_file.split('/')[-1].split('.')[0] # Extract name from file path
+        self.name = os.path.basename(sound_file).split('.')[0] # Extract name from file path
         self.sound = mixer.Sound(sound_file)
         self.loops = loops
         self.maxtime = maxtime


### PR DESCRIPTION
When dealing with OS functions like extracting parts of a path, or finding the users home directory it is best to defer to OS agnostic methods where available.

Also adding a /working folder to .gitignore exclusions so we can have add code to our local environments in the project for trial solutions that re not committed to the repo.